### PR TITLE
Add support for ARM architecture hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,7 @@ k3s_type: master
 k3s_addtionnal_config:
 k3s_master_node_address:
 k3s_cluster_token:
+k3s_binary_map:
+  x86_64: "k3s"
+  arm: "k3s-armhf"
+  aarch64: "k3s-arm64"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 - name: install | download k3s binary
   get_url:
-    url: https://github.com/rancher/k3s/releases/download/v{{ k3s_version }}/k3s
+    url: https://github.com/rancher/k3s/releases/download/v{{ k3s_version }}/{{ k3s_binary_map[ansible_facts.architecture] }}
     dest: /usr/local/bin/k3s
     validate_certs: yes
     owner: root


### PR DESCRIPTION
First of all, thank you for creating this Ansible role.
I've noticed that it doesn't support installing on ARM architecture, so here we go :)
With those changes I was able to bootstrap a 4 node ARM64 cluster.