### PR TITLE
Fix k3s agent systemd template

### DIFF
--- a/templates/k3s-agent.service.j2
+++ b/templates/k3s-agent.service.j2
@@ -13,4 +13,4 @@ LimitNPROC=infinity
 LimitCORE=infinity
 TasksMax=infinity
 [Install]
-WantedBy=multi-user.targets
+WantedBy=multi-user.target


### PR DESCRIPTION
I've noticed that the agents would not autostart after a reboot. I've tried using `systemctl enable k3s` but this also failed with a rather ambiguous error `Failed to enable unit: Invalid argument`, so after looking at the unit file I've found out that there is a small typo `WantedBy=multi-user.targets` instead of `WantedBy=multi-user.target`. Fixing it resolves the issue.