### PR TITLE
Add k3s service autostart

### DIFF
--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -3,6 +3,7 @@
   service:
     name: k3s
     state: started
+    enabled: yes
 
 - name: start | wait for master node to be ready
   command: "/usr/local/bin/k3s kubectl get nodes"


### PR DESCRIPTION
Most of the Linux distributions do not enable services by default (I'm
looking at you Debian and Ubuntu), so this ensures that k3s is enabled
on boot on all of the distributions.