### PR TITLE
Added support for RPi3B+ (armv7l)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,5 @@ k3s_cluster_token:
 k3s_binary_map:
   x86_64: "k3s"
   arm: "k3s-armhf"
+  armv7l: "k3s-armhf"
   aarch64: "k3s-arm64"


### PR DESCRIPTION
Architecture for Raspberry Pi 3 Model B+ is armv7l. My current workaround is to overwrite `k3s_binary_map` in group_vars. A merge of this change would make this playbook run without having to overwrite variables.