### PR TITLE
Add binary checksum verification on download

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,12 @@ k3s_type: master
 k3s_addtionnal_config:
 k3s_master_node_address:
 k3s_cluster_token:
+k3s_download_url_base: https://github.com/rancher/k3s/releases/download
+k3s_checksum_map:
+  x86_64: amd64
+  arm: armhf
+  armv7l: armhf
+  aarch64: arm64
 k3s_binary_map:
   x86_64: "k3s"
   arm: "k3s-armhf"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,8 @@
 ---
 - name: install | download k3s binary
   get_url:
-    url: https://github.com/rancher/k3s/releases/download/v{{ k3s_version }}/{{ k3s_binary_map[ansible_facts.architecture] }}
+    url: "{{ k3s_download_url_base }}/v{{ k3s_version }}/{{ k3s_binary_map[ansible_facts.architecture] }}"
+    checksum: sha256:{{ k3s_download_url_base }}/v{{ k3s_version }}/sha256sum-{{ k3s_checksum_map[ansible_facts.architecture] }}.txt
     dest: /usr/local/bin/k3s
     validate_certs: yes
     owner: root


### PR DESCRIPTION
I was hoping that implementing that would be really simple, but I haven't been able to figure out an elegant solution, due to the file naming differences in k3s, e.g. the amd64 binary is simply named `k3s` but the checksum file name is `sha256sum-amd64`. Due to that I've had to add yet another helper variable for checksum file naming.